### PR TITLE
Finally fix stale file path in the VCE Launcher documentation chapter

### DIFF
--- a/docs/source/getting_started/launcher.rst
+++ b/docs/source/getting_started/launcher.rst
@@ -21,7 +21,7 @@ To try this out with an example, go to the root folder of your VCE installation 
     scripts/vce-launcher.py \
         --container \
         --prepare-only \
-        networks/paderborn-north/with-minimap-and-bike-interface.launcher.toml
+        scenarios/paderborn-north/with-minimap-and-bike-interface.launcher.toml
 
 Here, ``--container`` means that each component will be launched using the Apptainer image ``vce-container.sif`` that ``scripts/vce-install-container.sh`` downloads automatically.
 


### PR DESCRIPTION
Previously, the code block used the old path `networks/paderborn-north/with-minimap-and-bike-interface.launcher.toml`.

The `networks` directory has been renamed to `scenarios` for some time now.